### PR TITLE
Bumped fiji-lib version to 2.0.1

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -154,7 +154,7 @@
 		<blockmatching.version>2.0.0-SNAPSHOT</blockmatching.version>
 		<fake.version>2.0.0-SNAPSHOT</fake.version>
 		<fiji-compat.version>2.0.0-SNAPSHOT</fiji-compat.version>
-		<fiji-lib.version>2.0.0</fiji-lib.version>
+		<fiji-lib.version>2.0.1</fiji-lib.version>
 		<fiji-scripting.version>2.0.0-SNAPSHOT</fiji-scripting.version>
 		<image5d.version>1.2.5</image5d.version>
 		<imagescience.version>2.4.2-SNAPSHOT</imagescience.version>


### PR DESCRIPTION
- fiji-lib:2.0.0 still held obsolete groupId references from pom-fiji
