### PR TITLE
update jitk-tps and trakem2_tps versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -270,13 +270,13 @@ Projects wishing to use pom-fiji as a parent project need to override the &lt;na
 		<Sholl_Analysis.version>3.4.6</Sholl_Analysis.version>
 
 		<!-- JITK TPS - https://github.com/saalfeldlab/jitk-tps -->
-		<jitk-tps.version>1.3.1</jitk-tps.version>
+		<jitk-tps.version>2.0.0</jitk-tps.version>
 
 		<!-- BigWarp - https://github.com/saalfeldlab/bigwarp -->
 		<bigwarp.version>2.1.1</bigwarp.version>
 
 		<!-- TrakEM2 TPS - https://github.com/saalfeldlab/trakem2-tps -->
-		<trakem2_tps.version>1.1.1</trakem2_tps.version>
+		<trakem2_tps.version>1.1.2</trakem2_tps.version>
 
 		<!-- Third party projects -->
 


### PR DESCRIPTION
bigwarp 2.1.1 
https://github.com/fiji/pom-fiji/blob/1cf0cde7da88325c97f0e49ce9d617b301f13ec9/pom.xml#L276
depends on jitk-tps-2.0.0.

this update to jitk-tps breaks trakem2_tps, hence the update to trakem2_tps-1.1.2