### PR TITLE
update jitk-tps and bigwarp versions

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -263,10 +263,10 @@ Projects wishing to use pom-fiji as a parent project need to override the &lt;na
 		<Sholl_Analysis.version>3.6.1</Sholl_Analysis.version>
 
 		<!-- JITK TPS - https://github.com/saalfeldlab/jitk-tps -->
-		<jitk-tps.version>2.0.0</jitk-tps.version>
+		<jitk-tps.version>2.1.0</jitk-tps.version>
 
 		<!-- BigWarp - https://github.com/saalfeldlab/bigwarp -->
-		<bigwarp.version>2.1.1</bigwarp.version>
+		<bigwarp.version>2.1.2</bigwarp.version>
 
 		<!-- TrakEM2 TPS - https://github.com/saalfeldlab/trakem2-tps -->
 		<trakem2_tps.version>1.1.2</trakem2_tps.version>


### PR DESCRIPTION
Along with assorted fixes and improvements, bigwarp_fiji-2.1.2 no longer contains the class `net.imglib2.display.ARGBARGBColorConverter` (which now lives in bdv-core)
See:
https://gitter.im/fiji/fiji?at=570800b98b7b2f457634f64b

Thanks @tpietzsch and @ctrueden !