### PR TITLE
Bump Sholl_Analysis version to v3.6.2

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -261,7 +261,7 @@ Projects wishing to use pom-fiji as a parent project need to override the &lt;na
 		<!-- External Fiji projects -->
 
 		<!-- Sholl Analysis - https://github.com/tferr/ASA -->
-		<Sholl_Analysis.version>3.6.1</Sholl_Analysis.version>
+		<Sholl_Analysis.version>3.6.2</Sholl_Analysis.version>
 
 		<!-- JITK TPS - https://github.com/saalfeldlab/jitk-tps -->
 		<jitk-tps.version>2.1.0</jitk-tps.version>


### PR DESCRIPTION
It fixes a bug cause by a [change in 1.50a](https://github.com/imagej/imagej1/issues/13) that makes the plugin unusable for 3D images, so it would be important if you guys could push it to the Fiji update site

(Sorry for including two commits. I am using the GitHub web interface and somehow did not manage to exclude the first one)